### PR TITLE
Fix layout centering on wide screens

### DIFF
--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -43,6 +43,7 @@ export default function InputBar({ onAddBookmark }: InputBarProps) {
       setTitle('');
       onAddBookmark();
     } catch (err) {
+      console.error('Failed to load image:', err);
       setError('Failed to load image. Please check the URL and try again.');
     } finally {
       setIsSubmitting(false);

--- a/src/index.css
+++ b/src/index.css
@@ -31,8 +31,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- remove flex centering from body to allow content to span full width
- log image loading errors to satisfy lint rules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a88af4d1f883238ba51c231631fd1f