### PR TITLE
feat: allow drag and drop image uploads

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,9 +57,10 @@ export default function App() {
       <Header />
       <main className="py-8">
         <InputBar onAddBookmark={handleAddBookmark} />
-        <Gallery 
-          onImageClick={handleImageClick} 
-          refreshTrigger={refreshTrigger} 
+        <Gallery
+          onImageClick={handleImageClick}
+          refreshTrigger={refreshTrigger}
+          onAddBookmark={handleAddBookmark}
         />
       </main>
 


### PR DESCRIPTION
## Summary
- support dragging image files or URLs into gallery grid to add bookmarks
- overlay drop zone and message prompts users when dragging
- wire gallery updates back to app

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9560312e8832386f24e942ced18f5