### PR TITLE
feat: add bookmark search filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.1",
@@ -27,6 +28,7 @@
     "tailwindcss": "^3.3.3",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "vitest": "^2.1.4"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ export default function App() {
   const [bookmarks, setBookmarks] = useState<ImageBookmark[]>([]);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
 
   // Load bookmarks on initial render
   useEffect(() => {
@@ -54,13 +55,14 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
-      <Header />
+      <Header searchQuery={searchQuery} onSearchChange={setSearchQuery} />
       <main className="py-8">
         <InputBar onAddBookmark={handleAddBookmark} />
         <Gallery
           onImageClick={handleImageClick}
           refreshTrigger={refreshTrigger}
           onAddBookmark={handleAddBookmark}
+          searchQuery={searchQuery}
         />
       </main>
 

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -2,14 +2,16 @@ import { useEffect, useState } from 'react';
 import type { ImageBookmark } from '../types';
 import { addBookmark, loadBookmarks, removeBookmark } from '../lib/storage';
 import { formatDate, isValidImageUrl } from '../utils/validation';
+import { filterBookmarks } from '../utils/filterBookmarks';
 
 interface GalleryProps {
   onImageClick: (index: number) => void;
   refreshTrigger: number;
   onAddBookmark: () => void;
+  searchQuery: string;
 }
 
-export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark }: GalleryProps) {
+export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark, searchQuery }: GalleryProps) {
   const [bookmarks, setBookmarks] = useState<ImageBookmark[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [infoVisibleId, setInfoVisibleId] = useState<string | null>(null);
@@ -74,6 +76,8 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark }:
     }
   };
 
+  const filteredBookmarks = filterBookmarks(bookmarks, searchQuery);
+
   if (isLoading) {
     return (
       <div className="flex justify-center items-center h-64">
@@ -96,79 +100,84 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark }:
         </div>
       )}
 
-      {bookmarks.length === 0 ? (
+      {filteredBookmarks.length === 0 ? (
         <div className="text-center py-12">
-          <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300">No bookmarks yet</h3>
+          <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300">
+            {bookmarks.length === 0 ? 'No bookmarks yet' : 'No bookmarks found'}
+          </h3>
           <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
             Add an image URL or drag and drop an image to get started!
           </p>
         </div>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-          {bookmarks.map((bookmark, index) => (
-            <div
-              key={bookmark.id}
-              onClick={() => onImageClick(index)}
-              className="group relative aspect-[4/3] rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-transform duration-200 cursor-pointer bg-gray-100 dark:bg-gray-800 hover:z-10 hover:scale-105"
-              role="button"
-            tabIndex={0}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                onImageClick(index);
-              }
-            }}
-          >
-            <div className="relative w-full h-full">
-              <img
-                src={bookmark.url}
-                alt={bookmark.title || 'Bookmarked image'}
-                className="w-full h-full object-cover"
-                loading="lazy"
-                onError={(e) => {
-                  const target = e.target as HTMLImageElement;
-                  target.onerror = null;
-                  target.src = 'data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%22800%22%20height%3D%22600%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20800%20600%22%20preserveAspectRatio%3D%22none%22%3E%3Cdefs%3E%3Cstyle%20type%3D%22text%2Fcss%22%3E%23holder_18e9f2f9c5f%20text%20%7B%20fill%3A%23AAAAAA%3Bfont-weight%3Abold%3Bfont-family%3AArial%2C%20Helvetica%2C%20Open%20Sans%2C%20sans-serif%2C%20monospace%3Bfont-size%3A40pt%20%7D%20%3C%2Fstyle%3E%3C%2Fdefs%3E%3Cg%20id%3D%22holder_18e9f2f9c5f%22%3E%3Crect%20width%3D%22800%22%20height%3D%22600%22%20fill%3D%22%23EEEEEE%22%3E%3C%2Frect%3E%3Cg%3E%3Ctext%20x%3D%22285.921875%22%20y%3D%22317.7%22%3EFailed%20to%20load%3C%2Ftext%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E';
-                }}
-              />
-              
+          {filteredBookmarks.map((bookmark) => {
+            const originalIndex = bookmarks.findIndex(b => b.id === bookmark.id);
+            return (
               <div
-                className={`absolute inset-0 bg-black/60 flex items-end p-2 transition-opacity duration-200 z-10 ${infoVisibleId === bookmark.id ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
-                onClick={(e) => e.stopPropagation()}
+                key={bookmark.id}
+                onClick={() => onImageClick(originalIndex)}
+                className="group relative aspect-[4/3] rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-transform duration-200 cursor-pointer bg-gray-100 dark:bg-gray-800 hover:z-10 hover:scale-105"
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onImageClick(originalIndex);
+                  }
+                }}
               >
-                <div className="w-full p-2 bg-gradient-to-t from-black/80 to-transparent text-white">
-                  <h3 className="font-medium truncate">{bookmark.title || 'Untitled'}</h3>
-                  <p className="text-xs opacity-80">{formatDate(bookmark.createdAt)}</p>
+                <div className="relative w-full h-full">
+                  <img
+                    src={bookmark.url}
+                    alt={bookmark.title || 'Bookmarked image'}
+                    className="w-full h-full object-cover"
+                    loading="lazy"
+                    onError={(e) => {
+                      const target = e.target as HTMLImageElement;
+                      target.onerror = null;
+                      target.src = 'data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%22800%22%20height%3D%22600%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20800%20600%22%20preserveAspectRatio%3D%22none%22%3E%3Cdefs%3E%3Cstyle%20type%3D%22text%2Fcss%22%3E%23holder_18e9f2f9c5f%20text%20%7B%20fill%3A%23AAAAAA%3Bfont-weight%3Abold%3Bfont-family%3AArial%2C%20Helvetica%2C%20Open%20Sans%2C%20sans-serif%2C%20monospace%3Bfont-size%3A40pt%20%7D%20%3C%2Fstyle%3E%3C%2Fdefs%3E%3Cg%20id%3D%22holder_18e9f2f9c5f%22%3E%3Crect%20width%3D%22800%22%20height%3D%22600%22%20fill%3D%22%23EEEEEE%22%3E%3C%2Frect%3E%3Cg%3E%3Ctext%20x%3D%22285.921875%22%20y%3D%22317.7%22%3EFailed%20to%20load%3C%2Ftext%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E';
+                    }}
+                  />
+
+                  <div
+                    className={`absolute inset-0 bg-black/60 flex items-end p-2 transition-opacity duration-200 z-10 ${infoVisibleId === bookmark.id ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <div className="w-full p-2 bg-gradient-to-t from-black/80 to-transparent text-white">
+                      <h3 className="font-medium truncate">{bookmark.title || 'Untitled'}</h3>
+                      <p className="text-xs opacity-80">{formatDate(bookmark.createdAt)}</p>
+                    </div>
+                  </div>
+
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setInfoVisibleId(prev => (prev === bookmark.id ? null : bookmark.id));
+                    }}
+                    className="absolute bottom-2 right-2 p-1.5 bg-black/50 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity z-20"
+                    aria-label="Show info"
+                    title="Show info"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z" />
+                    </svg>
+                  </button>
+
+                  <button
+                    onClick={(e) => handleRemove(e, bookmark.id)}
+                    className={`absolute top-2 right-2 p-1.5 bg-red-500 text-white rounded-full transition-opacity z-20 hover:bg-red-600 ${infoVisibleId === bookmark.id ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+                    aria-label="Remove bookmark"
+                    title="Remove bookmark"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
                 </div>
               </div>
-
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setInfoVisibleId(prev => (prev === bookmark.id ? null : bookmark.id));
-                }}
-                className="absolute bottom-2 right-2 p-1.5 bg-black/50 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity z-20"
-                aria-label="Show info"
-                title="Show info"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z" />
-                </svg>
-              </button>
-
-              <button
-                onClick={(e) => handleRemove(e, bookmark.id)}
-                className={`absolute top-2 right-2 p-1.5 bg-red-500 text-white rounded-full transition-opacity z-20 hover:bg-red-600 ${infoVisibleId === bookmark.id ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
-                aria-label="Remove bookmark"
-                title="Remove bookmark"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-          </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,22 @@
-export default function Header() {
+import { useEffect, useState } from 'react';
+
+interface HeaderProps {
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+}
+
+export default function Header({ searchQuery, onSearchChange }: HeaderProps) {
+  const [localQuery, setLocalQuery] = useState(searchQuery);
+
+  useEffect(() => {
+    setLocalQuery(searchQuery);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    const handler = setTimeout(() => onSearchChange(localQuery), 300);
+    return () => clearTimeout(handler);
+  }, [localQuery, onSearchChange]);
+
   return (
     <header className="bg-white dark:bg-gray-900 shadow-sm">
       <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
@@ -7,6 +25,15 @@ export default function Header() {
           <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
             Save image URLs. Browse them in a visual grid.
           </p>
+          <div className="mt-4">
+            <input
+              type="text"
+              value={localQuery}
+              onChange={(e) => setLocalQuery(e.target.value)}
+              placeholder="Search bookmarks..."
+              className="w-full max-w-md mx-auto px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+            />
+          </div>
         </div>
       </div>
     </header>

--- a/src/utils/filterBookmarks.test.ts
+++ b/src/utils/filterBookmarks.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import type { ImageBookmark } from '../types';
+import { filterBookmarks } from './filterBookmarks';
+
+const bookmarks: ImageBookmark[] = [
+  { id: '1', url: 'https://example.com/cat.jpg', title: 'Cat', createdAt: 0 },
+  { id: '2', url: 'https://example.com/dog.jpg', title: 'Dog', createdAt: 0 },
+  { id: '3', url: 'https://example.com/bird.jpg', createdAt: 0 },
+];
+
+describe('filterBookmarks', () => {
+  it('returns all bookmarks when query is empty', () => {
+    expect(filterBookmarks(bookmarks, '')).toEqual(bookmarks);
+  });
+
+  it('filters by title', () => {
+    const result = filterBookmarks(bookmarks, 'cat');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
+  });
+
+  it('filters by URL', () => {
+    const result = filterBookmarks(bookmarks, 'dog');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('2');
+  });
+
+  it('is case-insensitive', () => {
+    const result = filterBookmarks(bookmarks, 'BIRD');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('3');
+  });
+});

--- a/src/utils/filterBookmarks.ts
+++ b/src/utils/filterBookmarks.ts
@@ -1,0 +1,10 @@
+import type { ImageBookmark } from '../types';
+
+export function filterBookmarks(bookmarks: ImageBookmark[], query: string): ImageBookmark[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return bookmarks;
+  return bookmarks.filter(b =>
+    (b.title && b.title.toLowerCase().includes(q)) ||
+    b.url.toLowerCase().includes(q)
+  );
+}


### PR DESCRIPTION
## Summary
- add searchQuery state and input to filter bookmarks by title or URL
- filter gallery bookmarks and export filtering utility with tests

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a95c10136883239eb93f19219080e4