### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,16 @@
         flex-direction: column;
       }
     </style>
+    <script>
+      if (
+        localStorage.theme === 'dark' ||
+        (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
+      ) {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
+    </script>
   </head>
   <body>
     <div id="root">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,10 @@
+import ThemeToggle from './ThemeToggle';
+
 export default function Header() {
   return (
     <header className="bg-white dark:bg-gray-900 shadow-sm">
-      <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8 relative">
+        <ThemeToggle className="absolute top-4 right-4" />
         <div className="text-center">
           <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Image Bookmarker</h1>
           <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+interface ThemeToggleProps {
+  className?: string;
+}
+
+export default function ThemeToggle({ className = '' }: ThemeToggleProps) {
+  const [isDark, setIsDark] = useState(() =>
+    localStorage.theme === 'dark' ||
+    (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  );
+
+  useEffect(() => {
+    if (isDark) {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [isDark]);
+
+  return (
+    <button
+      onClick={() => setIsDark(!isDark)}
+      className={`p-2 rounded-md bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 transition-colors ${className}`}
+      aria-label="Toggle dark mode"
+    >
+      {isDark ? 'Light' : 'Dark'} Mode
+    </button>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- add a persistent dark mode toggle in the header
- enable class-based dark mode in Tailwind and initialize theme on load

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab3be9365483239f9b1c20c33b33c7