### PR TITLE
feat: enable editing bookmark titles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,13 @@ export default function App() {
     setRefreshTrigger(prev => prev + 1);
   };
 
+  const handleUpdateBookmark = (updated: ImageBookmark) => {
+    setBookmarks(prev =>
+      prev.map(bookmark => (bookmark.id === updated.id ? updated : bookmark))
+    );
+    setRefreshTrigger(prev => prev + 1);
+  };
+
   const handleImageClick = (index: number) => {
     setLightboxIndex(index);
     // Disable body scroll when lightbox is open
@@ -71,6 +78,7 @@ export default function App() {
           onClose={handleCloseLightbox}
           onNext={handleNextImage}
           onPrev={handlePrevImage}
+          onUpdateBookmark={handleUpdateBookmark}
         />
       )}
     </div>

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import type { ImageBookmark } from '../types';
 import { formatDate } from '../utils/validation';
+import { updateBookmark } from '../lib/storage';
 
 interface LightboxProps {
   bookmarks: ImageBookmark[];
@@ -8,6 +9,7 @@ interface LightboxProps {
   onClose: () => void;
   onNext: () => void;
   onPrev: () => void;
+  onUpdateBookmark: (bookmark: ImageBookmark) => void;
 }
 
 export default function Lightbox({
@@ -16,6 +18,7 @@ export default function Lightbox({
   onClose,
   onNext,
   onPrev,
+  onUpdateBookmark,
 }: LightboxProps) {
   const currentBookmark = bookmarks[currentIndex];
 
@@ -41,6 +44,22 @@ export default function Lightbox({
   }, [onClose, onNext, onPrev]);
 
   if (!currentBookmark) return null;
+
+  const handleEdit = () => {
+    const newTitle = window.prompt(
+      'Enter a title for this image',
+      currentBookmark.title || ''
+    );
+    if (newTitle === null) return;
+
+    const trimmed = newTitle.trim();
+    const updated = updateBookmark(currentBookmark.id, {
+      title: trimmed || undefined,
+    });
+    if (updated) {
+      onUpdateBookmark(updated);
+    }
+  };
 
   return (
     <div 
@@ -121,6 +140,12 @@ export default function Lightbox({
             {' • '}
             {currentIndex + 1} of {bookmarks.length}
           </p>
+          <button
+            onClick={handleEdit}
+            className="mt-2 px-3 py-1 bg-blue-600 hover:bg-blue-700 rounded text-sm"
+          >
+            Edit title
+          </button>
         </div>
       </div>
     </div>

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -33,6 +33,24 @@ export function addBookmark(bookmark: Omit<ImageBookmark, 'id' | 'createdAt'>): 
   return newBookmark;
 }
 
+export function updateBookmark(
+  id: string,
+  updates: Partial<Omit<ImageBookmark, 'id' | 'createdAt'>>
+): ImageBookmark | null {
+  const bookmarks = loadBookmarks();
+  const index = bookmarks.findIndex(bookmark => bookmark.id === id);
+  if (index === -1) return null;
+
+  const updatedBookmark: ImageBookmark = {
+    ...bookmarks[index],
+    ...updates,
+  };
+
+  bookmarks[index] = updatedBookmark;
+  saveBookmarks(bookmarks);
+  return updatedBookmark;
+}
+
 export function removeBookmark(id: string): void {
   const bookmarks = loadBookmarks().filter(bookmark => bookmark.id !== id);
   saveBookmarks(bookmarks);


### PR DESCRIPTION
## Summary
- add updateBookmark method to storage
- support updating bookmark titles in app state
- allow editing titles in lightbox

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab413fdc208323bc4bcb976f0cb304