### PR TITLE
feat: show image URLs in overlays

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -139,6 +139,14 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark }:
                 <div className="w-full p-2 bg-gradient-to-t from-black/80 to-transparent text-white">
                   <h3 className="font-medium truncate">{bookmark.title || 'Untitled'}</h3>
                   <p className="text-xs opacity-80">{formatDate(bookmark.createdAt)}</p>
+                  <a
+                    href={bookmark.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-blue-300 hover:underline break-all mt-1"
+                  >
+                    {bookmark.url}
+                  </a>
                 </div>
               </div>
 

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -140,6 +140,14 @@ export default function Lightbox({
             {' • '}
             {currentIndex + 1} of {bookmarks.length}
           </p>
+          <a
+            href={currentBookmark.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block mt-1 text-sm text-blue-300 hover:underline break-all"
+          >
+            {currentBookmark.url}
+          </a>
           <button
             onClick={handleEdit}
             className="mt-2 px-3 py-1 bg-blue-600 hover:bg-blue-700 rounded text-sm"


### PR DESCRIPTION
## Summary
- display image URL in gallery info overlay
- show image URL link in lightbox viewer

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab4e12b404832394a35ec814d51f36