### PR TITLE
feat: add category filtering for image bookmarks

### DIFF
--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -1,0 +1,28 @@
+interface CategorySelectorProps {
+  categories: string[];
+  selected: string;
+  onSelect: (category: string) => void;
+}
+
+export default function CategorySelector({ categories, selected, onSelect }: CategorySelectorProps) {
+  return (
+    <div className="w-full max-w-4xl mx-auto p-4">
+      <label htmlFor="category-select" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        Filter by category
+      </label>
+      <select
+        id="category-select"
+        value={selected}
+        onChange={(e) => onSelect(e.target.value)}
+        className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
+      >
+        <option value="All">All</option>
+        {categories.map((cat) => (
+          <option key={cat} value={cat}>
+            {cat}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -7,9 +7,10 @@ interface GalleryProps {
   onImageClick: (index: number) => void;
   refreshTrigger: number;
   onAddBookmark: () => void;
+  selectedCategory: string;
 }
 
-export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark }: GalleryProps) {
+export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark, selectedCategory }: GalleryProps) {
   const [bookmarks, setBookmarks] = useState<ImageBookmark[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [infoVisibleId, setInfoVisibleId] = useState<string | null>(null);
@@ -26,6 +27,7 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark }:
     if (window.confirm('Are you sure you want to remove this bookmark?')) {
       removeBookmark(id);
       setBookmarks(bookmarks.filter(bookmark => bookmark.id !== id));
+      onAddBookmark();
     }
   };
 
@@ -52,7 +54,10 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark }:
     const newItems: ImageBookmark[] = [];
 
     if (droppedUrl && isValidImageUrl(droppedUrl)) {
-      const bookmark = addBookmark({ url: droppedUrl });
+      const bookmark = addBookmark({
+        url: droppedUrl,
+        category: selectedCategory !== 'All' ? selectedCategory : undefined,
+      });
       newItems.push(bookmark);
     }
 
@@ -64,7 +69,11 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark }:
         reader.onerror = () => reject(new Error('Failed to read file'));
         reader.readAsDataURL(file);
       });
-      const bookmark = addBookmark({ url: dataUrl, title: file.name });
+      const bookmark = addBookmark({
+        url: dataUrl,
+        title: file.name,
+        category: selectedCategory !== 'All' ? selectedCategory : undefined,
+      });
       newItems.push(bookmark);
     }
 
@@ -81,6 +90,10 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark }:
       </div>
     );
   }
+
+  const filteredBookmarks = selectedCategory === 'All'
+    ? bookmarks
+    : bookmarks.filter(b => b.category === selectedCategory);
 
   return (
     <div
@@ -103,9 +116,13 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark }:
             Add an image URL or drag and drop an image to get started!
           </p>
         </div>
+      ) : filteredBookmarks.length === 0 ? (
+        <div className="text-center py-12">
+          <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300">No bookmarks in this category</h3>
+        </div>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-          {bookmarks.map((bookmark, index) => (
+          {filteredBookmarks.map((bookmark, index) => (
             <div
               key={bookmark.id}
               onClick={() => onImageClick(index)}

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -1,16 +1,23 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { isValidImageUrl } from '../utils/validation';
 import { addBookmark } from '../lib/storage';
 
 interface InputBarProps {
   onAddBookmark: () => void;
+  selectedCategory: string;
 }
 
-export default function InputBar({ onAddBookmark }: InputBarProps) {
+export default function InputBar({ onAddBookmark, selectedCategory }: InputBarProps) {
   const [url, setUrl] = useState('');
   const [title, setTitle] = useState('');
+  const [category, setCategory] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    // Default the category input to the currently selected category
+    setCategory(selectedCategory !== 'All' ? selectedCategory : '');
+  }, [selectedCategory]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -38,9 +45,14 @@ export default function InputBar({ onAddBookmark }: InputBarProps) {
       });
 
       // Add to bookmarks if image loads successfully
-      addBookmark({ url, title: title.trim() || undefined });
+      addBookmark({
+        url,
+        title: title.trim() || undefined,
+        category: category.trim() || undefined,
+      });
       setUrl('');
       setTitle('');
+      setCategory(selectedCategory !== 'All' ? selectedCategory : '');
       onAddBookmark();
     } catch (err) {
       console.error('Failed to load image:', err);
@@ -79,6 +91,21 @@ export default function InputBar({ onAddBookmark }: InputBarProps) {
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             placeholder="My beautiful image"
+            className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
+            disabled={isSubmitting}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="image-category" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Category (optional)
+          </label>
+          <input
+            id="image-category"
+            type="text"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            placeholder="e.g. nature, art"
             className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
             disabled={isSubmitting}
           />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,5 +2,9 @@ export type ImageBookmark = {
   id: string;
   url: string;
   title?: string;
+  /**
+   * Optional category or topic used for filtering bookmarks
+   */
+  category?: string;
   createdAt: number;
 };


### PR DESCRIPTION
## Summary
- allow users to tag bookmarks with categories
- filter gallery view by category with a new selector component
- persist selected category when adding or dragging images

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab6f088604832397bedd486e924ffe