### PR TITLE
feat: add smart search and indexing for bookmarks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ export default function App() {
   const [bookmarks, setBookmarks] = useState<ImageBookmark[]>([]);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const [lightboxBookmarks, setLightboxBookmarks] = useState<ImageBookmark[]>([]);
   const [selectedCategory, setSelectedCategory] = useState('All');
 
   // Load bookmarks on initial render
@@ -38,12 +39,6 @@ export default function App() {
     return Array.from(set);
   }, [bookmarks]);
 
-  const filteredBookmarks = useMemo(() => {
-    return selectedCategory === 'All'
-      ? bookmarks
-      : bookmarks.filter(b => b.category === selectedCategory);
-  }, [bookmarks, selectedCategory]);
-
   useEffect(() => {
     if (selectedCategory !== 'All' && !categories.includes(selectedCategory)) {
       setSelectedCategory('All');
@@ -54,10 +49,14 @@ export default function App() {
     setBookmarks(prev =>
       prev.map(bookmark => (bookmark.id === updated.id ? updated : bookmark))
     );
+    setLightboxBookmarks(prev =>
+      prev.map(bookmark => (bookmark.id === updated.id ? updated : bookmark))
+    );
     setRefreshTrigger(prev => prev + 1);
   };
 
-  const handleImageClick = (index: number) => {
+  const handleImageClick = (index: number, items: ImageBookmark[]) => {
+    setLightboxBookmarks(items);
     setLightboxIndex(index);
     // Disable body scroll when lightbox is open
     document.body.style.overflow = 'hidden';
@@ -70,7 +69,7 @@ export default function App() {
   };
 
   const handleNextImage = () => {
-    if (lightboxIndex !== null && lightboxIndex < filteredBookmarks.length - 1) {
+    if (lightboxIndex !== null && lightboxIndex < lightboxBookmarks.length - 1) {
       setLightboxIndex(lightboxIndex + 1);
     }
   };
@@ -139,7 +138,7 @@ export default function App() {
 
       {lightboxIndex !== null && (
         <Lightbox
-          bookmarks={filteredBookmarks}
+          bookmarks={lightboxBookmarks}
           currentIndex={lightboxIndex}
           onClose={handleCloseLightbox}
           onNext={handleNextImage}

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -10,6 +10,7 @@ interface InputBarProps {
 export default function InputBar({ onAddBookmark, selectedCategory }: InputBarProps) {
   const [url, setUrl] = useState('');
   const [title, setTitle] = useState('');
+  const [sourceUrl, setSourceUrl] = useState('');
   const [category, setCategory] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState('');
@@ -48,10 +49,12 @@ export default function InputBar({ onAddBookmark, selectedCategory }: InputBarPr
       addBookmark({
         url,
         title: title.trim() || undefined,
+        sourceUrl: sourceUrl.trim() || undefined,
         category: category.trim() || undefined,
       });
       setUrl('');
       setTitle('');
+      setSourceUrl('');
       setCategory(selectedCategory !== 'All' ? selectedCategory : '');
       onAddBookmark();
     } catch (err) {
@@ -78,6 +81,21 @@ export default function InputBar({ onAddBookmark, selectedCategory }: InputBarPr
             className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
             disabled={isSubmitting}
             required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="source-url" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Source Page URL (optional)
+          </label>
+          <input
+            id="source-url"
+            type="url"
+            value={sourceUrl}
+            onChange={(e) => setSourceUrl(e.target.value)}
+            placeholder="https://example.com"
+            className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
+            disabled={isSubmitting}
           />
         </div>
         

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,8 +3,20 @@ export type ImageBookmark = {
   url: string;
   title?: string;
   /**
+   * Optional source page URL where this image was found
+   */
+  sourceUrl?: string;
+  /**
    * Optional category or topic used for filtering bookmarks
    */
   category?: string;
+  /**
+   * Optional list of topics associated with this bookmark
+   */
+  topics?: string[];
   createdAt: number;
+  /**
+   * Precomputed tokens used for fast searching
+   */
+  searchTokens?: string[];
 };

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,0 +1,78 @@
+import type { ImageBookmark } from '../types';
+
+export function normalize(str: string): string {
+  return str
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+export function tokenize(str: string): string[] {
+  return normalize(str).split(' ').filter(Boolean);
+}
+
+export function buildSearchTokens(img: ImageBookmark): string[] {
+  const tokens = new Set<string>();
+  const add = (value?: string | string[]) => {
+    if (!value) return;
+    const text = Array.isArray(value) ? value.join(' ') : value;
+    tokenize(text).forEach(t => tokens.add(t));
+  };
+  add(img.title);
+  add(img.url);
+  add(img.sourceUrl);
+  if (img.topics) add(img.topics);
+  if (img.category) add(img.category);
+  return Array.from(tokens);
+}
+
+export interface SearchResult {
+  bookmark: ImageBookmark;
+  score: number;
+}
+
+export function searchImages(images: ImageBookmark[], query: string): SearchResult[] {
+  const qTokens = tokenize(query);
+  if (qTokens.length === 0) {
+    return images
+      .slice()
+      .sort((a, b) => b.createdAt - a.createdAt)
+      .map(b => ({ bookmark: b, score: 0 }));
+  }
+
+  const results: SearchResult[] = [];
+
+  for (const img of images) {
+    const tokens = img.searchTokens || buildSearchTokens(img);
+    const titleTokens = img.title ? tokenize(img.title) : [];
+    let score = 0;
+    for (const qt of qTokens) {
+      if (titleTokens.includes(qt)) {
+        score += 3;
+      } else if (tokens.some(t => t.startsWith(qt))) {
+        score += 2;
+      } else {
+        const urlText =
+          (img.url ? normalize(img.url) : '') +
+          ' ' +
+          (img.sourceUrl ? normalize(img.sourceUrl) : '');
+        if (urlText.includes(qt)) {
+          score += 1;
+        }
+      }
+    }
+    if (score > 0) {
+      results.push({ bookmark: img, score });
+    }
+  }
+
+  results.sort(
+    (a, b) =>
+      b.score - a.score || b.bookmark.createdAt - a.bookmark.createdAt
+  );
+
+  return results;
+}
+


### PR DESCRIPTION
## Summary
- add search utilities and token index to bookmarks
- support source page url and debounced search in gallery
- rebuild search tokens on add/edit and migrate existing data

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5de779d9883238824ddd019822c07