### PR TITLE
feat: add scroll to top button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import InputBar from './components/InputBar';
 import Gallery from './components/Gallery';
 import Lightbox from './components/Lightbox';
 import CategorySelector from './components/CategorySelector';
+import ScrollToTopButton from './components/ScrollToTopButton';
 
 export default function App() {
   console.log('App component rendering...');
@@ -146,6 +147,7 @@ export default function App() {
           onUpdateBookmark={handleUpdateBookmark}
         />
       )}
+      <ScrollToTopButton />
     </div>
   );
 }

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+export default function ScrollToTopButton() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > 300);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const handleClick = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`fixed bottom-6 right-6 p-3 rounded-full bg-blue-600 text-white shadow-lg transition-opacity duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 ${isVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+      aria-label="Scroll to top"
+      title="Scroll to top"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-5 w-5"
+      >
+        <path d="M5 15l7-7 7 7" />
+      </svg>
+    </button>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add ScrollToTopButton component that reveals after scrolling and smooth scrolls to top
- integrate ScrollToTopButton into main app layout

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5e46119108323aef3d36bf7f73e9b