### PR TITLE
Fix shuffle breaking due to search sorting

### DIFF
--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -36,10 +36,7 @@ export interface SearchResult {
 export function searchImages(images: ImageBookmark[], query: string): SearchResult[] {
   const qTokens = tokenize(query);
   if (qTokens.length === 0) {
-    return images
-      .slice()
-      .sort((a, b) => b.createdAt - a.createdAt)
-      .map(b => ({ bookmark: b, score: 0 }));
+    return images.map(b => ({ bookmark: b, score: 0 }));
   }
 
   const results: SearchResult[] = [];


### PR DESCRIPTION
## Summary
- preserve bookmark order when no search query is provided, ensuring shuffle works

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b608af0d988323a75e4ae80f9af406