### PR TITLE
Support multiple categories per bookmark

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ export default function App() {
   const categories = useMemo(() => {
     const set = new Set<string>();
     bookmarks.forEach(b => {
-      if (b.category) set.add(b.category);
+      b.categories?.forEach((cat) => set.add(cat));
     });
     return Array.from(set);
   }, [bookmarks]);

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -95,7 +95,7 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark, s
     if (droppedUrl && isValidImageUrl(droppedUrl)) {
       const bookmark = addBookmark({
         url: droppedUrl,
-        category: selectedCategory !== 'All' ? selectedCategory : undefined,
+        categories: selectedCategory !== 'All' ? [selectedCategory] : undefined,
       });
       newItems.push(bookmark);
     }
@@ -111,7 +111,7 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark, s
       const bookmark = addBookmark({
         url: dataUrl,
         title: file.name,
-        category: selectedCategory !== 'All' ? selectedCategory : undefined,
+        categories: selectedCategory !== 'All' ? [selectedCategory] : undefined,
       });
       newItems.push(bookmark);
     }
@@ -124,7 +124,7 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark, s
 
   const filteredByCategory = selectedCategory === 'All'
     ? bookmarks
-    : bookmarks.filter(b => b.category === selectedCategory);
+    : bookmarks.filter(b => b.categories?.includes(selectedCategory));
 
   const searchResults = useMemo(
     () => searchImages(filteredByCategory, debouncedSearch),

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -11,13 +11,13 @@ export default function InputBar({ onAddBookmark, selectedCategory }: InputBarPr
   const [url, setUrl] = useState('');
   const [title, setTitle] = useState('');
   const [sourceUrl, setSourceUrl] = useState('');
-  const [category, setCategory] = useState('');
+  const [categories, setCategories] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState('');
 
   useEffect(() => {
-    // Default the category input to the currently selected category
-    setCategory(selectedCategory !== 'All' ? selectedCategory : '');
+    // Default the categories input to the currently selected category
+    setCategories(selectedCategory !== 'All' ? selectedCategory : '');
   }, [selectedCategory]);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -50,12 +50,15 @@ export default function InputBar({ onAddBookmark, selectedCategory }: InputBarPr
         url,
         title: title.trim() || undefined,
         sourceUrl: sourceUrl.trim() || undefined,
-        category: category.trim() || undefined,
+        categories: categories
+          .split(',')
+          .map((c) => c.trim())
+          .filter(Boolean),
       });
       setUrl('');
       setTitle('');
       setSourceUrl('');
-      setCategory(selectedCategory !== 'All' ? selectedCategory : '');
+      setCategories(selectedCategory !== 'All' ? selectedCategory : '');
       onAddBookmark();
     } catch (err) {
       console.error('Failed to load image:', err);
@@ -115,14 +118,14 @@ export default function InputBar({ onAddBookmark, selectedCategory }: InputBarPr
         </div>
 
         <div>
-          <label htmlFor="image-category" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            Category (optional)
+          <label htmlFor="image-categories" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Categories (optional, comma separated)
           </label>
           <input
-            id="image-category"
+            id="image-categories"
             type="text"
-            value={category}
-            onChange={(e) => setCategory(e.target.value)}
+            value={categories}
+            onChange={(e) => setCategories(e.target.value)}
             placeholder="e.g. nature, art"
             className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
             disabled={isSubmitting}

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -67,6 +67,25 @@ export default function Lightbox({
     }
   };
 
+  const handleEditCategories = () => {
+    const existing = currentBookmark.categories?.join(', ') || '';
+    const input = window.prompt(
+      'Enter categories for this image, separated by commas',
+      existing
+    );
+    if (input === null) return;
+    const list = input
+      .split(',')
+      .map((c) => c.trim())
+      .filter(Boolean);
+    const updated = updateBookmark(currentBookmark.id, {
+      categories: list.length > 0 ? list : undefined,
+    });
+    if (updated) {
+      onUpdateBookmark(updated);
+    }
+  };
+
   return (
     <div 
       className="fixed inset-0 bg-black/90 z-50 flex flex-col items-center justify-center p-4"
@@ -154,12 +173,23 @@ export default function Lightbox({
           >
             {currentBookmark.url}
           </a>
-          <button
-            onClick={handleEdit}
-            className="mt-2 px-3 py-1 bg-blue-600 hover:bg-blue-700 rounded text-sm"
-          >
-            Edit title
-          </button>
+          <p className="text-sm text-gray-300 mt-1">
+            Categories: {currentBookmark.categories?.join(', ') || 'None'}
+          </p>
+          <div className="mt-2 space-x-2">
+            <button
+              onClick={handleEdit}
+              className="px-3 py-1 bg-blue-600 hover:bg-blue-700 rounded text-sm"
+            >
+              Edit title
+            </button>
+            <button
+              onClick={handleEditCategories}
+              className="px-3 py-1 bg-blue-600 hover:bg-blue-700 rounded text-sm"
+            >
+              Edit categories
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,9 +7,9 @@ export type ImageBookmark = {
    */
   sourceUrl?: string;
   /**
-   * Optional category or topic used for filtering bookmarks
+   * Optional categories used for filtering bookmarks
    */
-  category?: string;
+  categories?: string[];
   /**
    * Optional list of topics associated with this bookmark
    */

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -24,7 +24,10 @@ export function buildSearchTokens(img: ImageBookmark): string[] {
   add(img.url);
   add(img.sourceUrl);
   if (img.topics) add(img.topics);
-  if (img.category) add(img.category);
+  if (img.categories) add(img.categories);
+  // Support legacy single category field
+  const legacyCategory = (img as { category?: string }).category;
+  if (legacyCategory) add(legacyCategory);
   return Array.from(tokens);
 }
 


### PR DESCRIPTION
## Summary
- allow storing multiple categories per image bookmark
- enable adding categories when bookmarking or via the lightbox editor
- update gallery filtering and storage to work with category lists

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7293e02e48323a7c669eac9dc7e6d