### PR TITLE
feat: allow selecting existing categories when editing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -145,6 +145,7 @@ export default function App() {
           onNext={handleNextImage}
           onPrev={handlePrevImage}
           onUpdateBookmark={handleUpdateBookmark}
+          allCategories={categories}
         />
       )}
       <ScrollToTopButton />


### PR DESCRIPTION
## Summary
- enable editing categories using checkboxes for existing categories
- pass list of categories into lightbox for editing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b72cbd9a048323b80c82f2f0dd586a