### PR TITLE
Centralize image info editing in grid view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,16 +46,6 @@ export default function App() {
     }
   }, [categories, selectedCategory]);
 
-  const handleUpdateBookmark = (updated: ImageBookmark) => {
-    setBookmarks(prev =>
-      prev.map(bookmark => (bookmark.id === updated.id ? updated : bookmark))
-    );
-    setLightboxBookmarks(prev =>
-      prev.map(bookmark => (bookmark.id === updated.id ? updated : bookmark))
-    );
-    setRefreshTrigger(prev => prev + 1);
-  };
-
   const handleImageClick = (index: number, items: ImageBookmark[]) => {
     setLightboxBookmarks(items);
     setLightboxIndex(index);
@@ -144,8 +134,6 @@ export default function App() {
           onClose={handleCloseLightbox}
           onNext={handleNextImage}
           onPrev={handlePrevImage}
-          onUpdateBookmark={handleUpdateBookmark}
-          allCategories={categories}
         />
       )}
       <ScrollToTopButton />

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useState } from 'react';
 import type { ImageBookmark } from '../types';
-import { formatDate } from '../utils/validation';
-import EditBookmarkModal from './EditBookmarkModal';
 
 interface LightboxProps {
   bookmarks: ImageBookmark[];
@@ -9,8 +7,6 @@ interface LightboxProps {
   onClose: () => void;
   onNext: () => void;
   onPrev: () => void;
-  onUpdateBookmark: (bookmark: ImageBookmark) => void;
-  allCategories: string[];
 }
 
 export default function Lightbox({
@@ -19,14 +15,10 @@ export default function Lightbox({
   onClose,
   onNext,
   onPrev,
-  onUpdateBookmark,
-  allCategories,
 }: LightboxProps) {
   const currentBookmark = bookmarks[currentIndex];
 
   const [isZoomed, setIsZoomed] = useState(false);
-  const [showInfo, setShowInfo] = useState(false);
-  const [editing, setEditing] = useState(false);
 
   useEffect(() => {
     setIsZoomed(false);
@@ -55,16 +47,6 @@ export default function Lightbox({
 
   if (!currentBookmark) return null;
 
-  const truncate = (str: string, length = 30) =>
-    str.length > length ? `${str.slice(0, length)}...` : str;
-
-  const copyToClipboard = (text: string) => {
-    if (!text) return;
-    navigator.clipboard.writeText(text).catch((err) =>
-      console.error('Failed to copy:', err)
-    );
-  };
-
   return (
     <div 
       className="fixed inset-0 bg-black/90 z-50 flex flex-col items-center justify-center p-4"
@@ -87,20 +69,6 @@ export default function Lightbox({
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
-
-        {/* Info button */}
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            setShowInfo(true);
-          }}
-          className="absolute -top-10 left-0 p-2 bg-black/50 text-white hover:bg-black/70 hover:text-gray-300 rounded"
-          aria-label="Show info"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z" />
           </svg>
         </button>
 
@@ -159,105 +127,6 @@ export default function Lightbox({
         </div>
       </div>
 
-      {showInfo && (
-        <div
-          className="absolute inset-0 bg-black/80 flex items-center justify-center p-4"
-          onClick={() => setShowInfo(false)}
-          role="dialog"
-          aria-modal="true"
-          aria-label="Image information"
-        >
-          <div
-            className="bg-gray-800 text-white p-4 rounded w-full max-w-md"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h2 className="text-lg font-medium mb-4">Image Info</h2>
-            <div className="mb-2 flex items-center">
-              <span className="mr-2 font-medium">Title:</span>
-              <span className="mr-2">{truncate(currentBookmark.title || '')}</span>
-              <button
-                onClick={() => copyToClipboard(currentBookmark.title || '')}
-                className="p-1 bg-black/30 rounded hover:bg-black/50"
-                aria-label="Copy title"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2" />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M8 8h8a2 2 0 012 2v8a2 2 0 01-2 2H8a2 2 0 01-2-2V8z" />
-                </svg>
-              </button>
-            </div>
-            <div className="mb-2 flex items-center">
-              <span className="mr-2 font-medium">URL:</span>
-              <span className="mr-2">{truncate(currentBookmark.url)}</span>
-              <button
-                onClick={() => copyToClipboard(currentBookmark.url)}
-                className="p-1 bg-black/30 rounded hover:bg-black/50"
-                aria-label="Copy URL"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2" />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M8 8h8a2 2 0 012 2v8a2 2 0 01-2 2H8a2 2 0 01-2-2V8z" />
-                </svg>
-              </button>
-            </div>
-            <p className="mb-2 text-sm">Date: {formatDate(currentBookmark.createdAt)}</p>
-            <p className="mb-4 text-sm">
-              Categories: {currentBookmark.categories?.join(', ') || 'None'}
-            </p>
-            <div className="flex justify-end">
-              <button
-                onClick={() => {
-                  setShowInfo(false);
-                  setEditing(true);
-                }}
-                className="px-3 py-1 bg-blue-600 hover:bg-blue-700 rounded text-sm"
-              >
-                Edit
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {editing && (
-        <EditBookmarkModal
-          bookmark={currentBookmark}
-          allCategories={allCategories}
-          onClose={() => setEditing(false)}
-          onSave={(updated) => {
-            onUpdateBookmark(updated);
-            setEditing(false);
-          }}
-        />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove slideshow information button and editing logic from `Lightbox`
- add edit action to grid information panel with modal dialog
- simplify `App` `Lightbox` usage now that info editing lives only in the grid

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdf91a332083238000ff8ec74b24cc