### PR TITLE
Move expand button above note box

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -313,7 +313,7 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark, s
                           e.stopPropagation();
                           setInfoVisibleId(prev => (prev === bookmark.id ? null : bookmark.id));
                         }}
-                        className="absolute bottom-2 right-2 p-1.5 bg-black/50 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity z-20"
+                        className="absolute top-2 left-2 p-1.5 bg-black/50 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity z-20"
                         aria-label="Show info"
                         title="Show info"
                       >


### PR DESCRIPTION
## Summary
- Reposition info expand button to top-left so it sits above the note overlay

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be095bb9008323a7a27a56f675994b