### PR TITLE
Hide image actions when gallery is empty

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,37 +105,31 @@ export default function App() {
             </button>
           </div>
         )}
-        <CategorySelector
-          categories={categories}
-          selected={selectedCategory}
-          onSelect={setSelectedCategory}
-        />
-        <div className="w-full max-w-4xl mx-auto p-4 flex gap-4">
-          <button
-            type="button"
-            onClick={handleShuffle}
-            disabled={bookmarks.length === 0}
-            className={`px-4 py-2 rounded-md text-white font-medium ${
-              bookmarks.length === 0
-                ? 'bg-purple-400 cursor-not-allowed'
-                : 'bg-purple-600 hover:bg-purple-700'
-            } transition-colors`}
-          >
-            Shuffle Images
-          </button>
-          <button
-            type="button"
-            onClick={handleReorder}
-            disabled={bookmarks.length === 0}
-            className={`px-4 py-2 rounded-md text-white font-medium ${
-              bookmarks.length === 0
-                ? 'bg-gray-400 cursor-not-allowed'
-                : 'bg-gray-600 hover:bg-gray-700'
-            } transition-colors`}
-          >
-            Reorder Images
-          </button>
-        </div>
+        {bookmarks.length > 0 && (
+          <>
+            <CategorySelector
+              categories={categories}
+              selected={selectedCategory}
+              onSelect={setSelectedCategory}
+            />
+            <div className="w-full max-w-4xl mx-auto p-4 flex gap-4">
+              <button
+                type="button"
+                onClick={handleShuffle}
+                className="px-4 py-2 rounded-md text-white font-medium bg-purple-600 hover:bg-purple-700 transition-colors"
+              >
+                Shuffle Images
+              </button>
+              <button
+                type="button"
+                onClick={handleReorder}
+                className="px-4 py-2 rounded-md text-white font-medium bg-gray-600 hover:bg-gray-700 transition-colors"
+              >
+                Reorder Images
+              </button>
+            </div>
+          </>
+        )}
         <Gallery
           onImageClick={handleImageClick}
           refreshTrigger={refreshTrigger}

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -165,58 +165,55 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark, s
         </div>
       )}
 
-      <div className="mb-4">
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Escape') setSearch('');
-          }}
-          placeholder="Search images..."
-          className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
-        />
-      </div>
-
       {bookmarks.length > 0 && (
-        <div className="mb-4 flex gap-2">
-          {selectMode ? (
-            <>
-              <button
-                type="button"
-                onClick={handleDeleteSelected}
-                disabled={selectedIds.length === 0}
-                className={`px-3 py-1 rounded-md text-white font-medium ${
-                  selectedIds.length === 0
-                    ? 'bg-red-300 cursor-not-allowed'
-                    : 'bg-red-600 hover:bg-red-700'
-                } transition-colors`}
-              >
-                Delete Selected ({selectedIds.length})
-              </button>
+        <>
+          <div className="mb-4">
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') setSearch('');
+              }}
+              placeholder="Search images..."
+              className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
+            />
+          </div>
+
+          <div className="mb-4 flex gap-2">
+            {selectMode ? (
+              <>
+                <button
+                  type="button"
+                  onClick={handleDeleteSelected}
+                  disabled={selectedIds.length === 0}
+                  className={`px-3 py-1 rounded-md text-white font-medium ${
+                    selectedIds.length === 0
+                      ? 'bg-red-300 cursor-not-allowed'
+                      : 'bg-red-600 hover:bg-red-700'
+                  } transition-colors`}
+                >
+                  Delete Selected ({selectedIds.length})
+                </button>
+                <button
+                  type="button"
+                  onClick={toggleSelectMode}
+                  className="px-3 py-1 rounded-md text-white font-medium bg-gray-600 hover:bg-gray-700 transition-colors"
+                >
+                  Cancel
+                </button>
+              </>
+            ) : (
               <button
                 type="button"
                 onClick={toggleSelectMode}
-                className="px-3 py-1 rounded-md text-white font-medium bg-gray-600 hover:bg-gray-700 transition-colors"
+                className="px-3 py-1 rounded-md text-white font-medium bg-red-600 hover:bg-red-700 transition-colors"
               >
-                Cancel
+                Select
               </button>
-            </>
-          ) : (
-            <button
-              type="button"
-              onClick={toggleSelectMode}
-              disabled={bookmarks.length === 0}
-              className={`px-3 py-1 rounded-md text-white font-medium ${
-                bookmarks.length === 0
-                  ? 'bg-gray-400 cursor-not-allowed'
-                  : 'bg-red-600 hover:bg-red-700'
-              } transition-colors`}
-            >
-              Select
-            </button>
-          )}
-        </div>
+            )}
+          </div>
+        </>
       )}
 
       {bookmarks.length === 0 ? (


### PR DESCRIPTION
## Summary
- Hide category filter, shuffle, and reorder buttons until bookmarks exist
- Suppress search and selection controls when gallery is empty

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be189f25ac8323b380af735f29331a