### PR TITLE
feat: replace category dropdown with chip selector

### DIFF
--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -7,22 +7,34 @@ interface CategorySelectorProps {
 export default function CategorySelector({ categories, selected, onSelect }: CategorySelectorProps) {
   return (
     <div className="w-full max-w-4xl mx-auto p-4">
-      <label htmlFor="category-select" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-        Filter by category
-      </label>
-      <select
-        id="category-select"
-        value={selected}
-        onChange={(e) => onSelect(e.target.value)}
-        className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
-      >
-        <option value="All">All</option>
+      <p className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Filter by category</p>
+      <div className="flex gap-2 overflow-x-auto">
+        <button
+          type="button"
+          onClick={() => onSelect('All')}
+          className={`px-3 py-1 rounded-full border flex-shrink-0 whitespace-nowrap text-sm transition-colors ${
+            selected === 'All'
+              ? 'bg-blue-600 text-white border-blue-600'
+              : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-700'
+          }`}
+        >
+          All
+        </button>
         {categories.map((cat) => (
-          <option key={cat} value={cat}>
+          <button
+            key={cat}
+            type="button"
+            onClick={() => onSelect(cat)}
+            className={`px-3 py-1 rounded-full border flex-shrink-0 whitespace-nowrap text-sm transition-colors ${
+              selected === cat
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-700'
+            }`}
+          >
             {cat}
-          </option>
+          </button>
         ))}
-      </select>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace category dropdown with inline chip selector for faster browsing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be1ff04f6c8323b9651c47cd688296