### PR TITLE
feat: replace category dropdown with chip selector and toggle search field

### DIFF
--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -7,22 +7,34 @@ interface CategorySelectorProps {
 export default function CategorySelector({ categories, selected, onSelect }: CategorySelectorProps) {
   return (
     <div className="w-full max-w-4xl mx-auto p-4">
-      <label htmlFor="category-select" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-        Filter by category
-      </label>
-      <select
-        id="category-select"
-        value={selected}
-        onChange={(e) => onSelect(e.target.value)}
-        className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
-      >
-        <option value="All">All</option>
+      <p className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Filter by category</p>
+      <div className="flex gap-2 overflow-x-auto">
+        <button
+          type="button"
+          onClick={() => onSelect('All')}
+          className={`px-3 py-1 rounded-full border flex-shrink-0 whitespace-nowrap text-sm transition-colors ${
+            selected === 'All'
+              ? 'bg-blue-600 text-white border-blue-600'
+              : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-700'
+          }`}
+        >
+          All
+        </button>
         {categories.map((cat) => (
-          <option key={cat} value={cat}>
+          <button
+            key={cat}
+            type="button"
+            onClick={() => onSelect(cat)}
+            className={`px-3 py-1 rounded-full border flex-shrink-0 whitespace-nowrap text-sm transition-colors ${
+              selected === cat
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-700'
+            }`}
+          >
             {cat}
-          </option>
+          </button>
         ))}
-      </select>
+      </div>
     </div>
   );
 }

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -19,6 +19,7 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark, s
   const [isDragging, setIsDragging] = useState(false);
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [showSearch, setShowSearch] = useState(false);
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [editingBookmark, setEditingBookmark] = useState<ImageBookmark | null>(null);
@@ -168,16 +169,38 @@ export default function Gallery({ onImageClick, refreshTrigger, onAddBookmark, s
       {bookmarks.length > 0 && (
         <>
           <div className="mb-4">
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Escape') setSearch('');
-              }}
-              placeholder="Search images..."
-              className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
-            />
+            {showSearch ? (
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Escape') setSearch('');
+                  }}
+                  placeholder="Search images..."
+                  className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
+                />
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSearch('');
+                    setShowSearch(false);
+                  }}
+                  className="px-3 py-2 rounded-md text-white font-medium bg-gray-600 hover:bg-gray-700 transition-colors"
+                >
+                  Close
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setShowSearch(true)}
+                className="px-3 py-2 rounded-md text-white font-medium bg-gray-600 hover:bg-gray-700 transition-colors"
+              >
+                Search Images
+              </button>
+            )}
           </div>
 
           <div className="mb-4 flex gap-2">


### PR DESCRIPTION
## Summary
- replace category dropdown with inline chip selector for faster browsing
- hide the "search images" field behind a toggle so it only appears when needed

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be1ff04f6c8323b9651c47cd688296