### PR TITLE
feat: replace category dropdown with chip selector and move search/select controls to action bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,8 @@ export default function App() {
   const [lightboxBookmarks, setLightboxBookmarks] = useState<ImageBookmark[]>([]);
   const [selectedCategory, setSelectedCategory] = useState('All');
   const [showInputBar, setShowInputBar] = useState(false);
+  const [showSearch, setShowSearch] = useState(false);
+  const [selectMode, setSelectMode] = useState(false);
 
   // Load bookmarks on initial render
   useEffect(() => {
@@ -115,6 +117,13 @@ export default function App() {
             <div className="w-full max-w-4xl mx-auto p-4 flex gap-4">
               <button
                 type="button"
+                onClick={() => setShowSearch(true)}
+                className="px-4 py-2 rounded-md text-white font-medium bg-blue-600 hover:bg-blue-700 transition-colors"
+              >
+                Search Images
+              </button>
+              <button
+                type="button"
                 onClick={handleShuffle}
                 className="px-4 py-2 rounded-md text-white font-medium bg-purple-600 hover:bg-purple-700 transition-colors"
               >
@@ -127,6 +136,15 @@ export default function App() {
               >
                 Reorder Images
               </button>
+              {!selectMode && (
+                <button
+                  type="button"
+                  onClick={() => setSelectMode(true)}
+                  className="px-4 py-2 rounded-md text-white font-medium bg-red-600 hover:bg-red-700 transition-colors"
+                >
+                  Select
+                </button>
+              )}
             </div>
           </>
         )}
@@ -135,6 +153,10 @@ export default function App() {
           refreshTrigger={refreshTrigger}
           onAddBookmark={handleAddBookmark}
           selectedCategory={selectedCategory}
+          selectMode={selectMode}
+          setSelectMode={setSelectMode}
+          showSearch={showSearch}
+          setShowSearch={setShowSearch}
         />
       </main>
 

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -7,22 +7,34 @@ interface CategorySelectorProps {
 export default function CategorySelector({ categories, selected, onSelect }: CategorySelectorProps) {
   return (
     <div className="w-full max-w-4xl mx-auto p-4">
-      <label htmlFor="category-select" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-        Filter by category
-      </label>
-      <select
-        id="category-select"
-        value={selected}
-        onChange={(e) => onSelect(e.target.value)}
-        className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
-      >
-        <option value="All">All</option>
+      <p className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Filter by category</p>
+      <div className="flex gap-2 overflow-x-auto">
+        <button
+          type="button"
+          onClick={() => onSelect('All')}
+          className={`px-3 py-1 rounded-full border flex-shrink-0 whitespace-nowrap text-sm transition-colors ${
+            selected === 'All'
+              ? 'bg-blue-600 text-white border-blue-600'
+              : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-700'
+          }`}
+        >
+          All
+        </button>
         {categories.map((cat) => (
-          <option key={cat} value={cat}>
+          <button
+            key={cat}
+            type="button"
+            onClick={() => onSelect(cat)}
+            className={`px-3 py-1 rounded-full border flex-shrink-0 whitespace-nowrap text-sm transition-colors ${
+              selected === cat
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-700'
+            }`}
+          >
             {cat}
-          </option>
+          </button>
         ))}
-      </select>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace category dropdown with inline chip selector for faster browsing
- hide the "search images" field behind a toggle and place its button in the action bar
- move the Select mode trigger alongside Shuffle and Reorder buttons

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be1ff04f6c8323b9651c47cd688296