### PR TITLE
Add default cat images for empty gallery

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -5,6 +5,7 @@ import { addBookmark, loadBookmarks, removeBookmark, removeBookmarks } from '../
 import { formatDate, isValidImageUrl } from '../utils/validation';
 import { searchImages } from '../utils/search';
 import EditBookmarkModal from './EditBookmarkModal';
+import { defaultImages } from '../data/defaultImages';
 
 interface GalleryProps {
   onImageClick: (index: number, items: ImageBookmark[]) => void;
@@ -238,11 +239,31 @@ export default function Gallery({
       )}
 
       {bookmarks.length === 0 ? (
-        <div className="text-center py-12">
-          <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300">No bookmarks yet</h3>
-          <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
-            Add an image URL or drag and drop an image to get started!
-          </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          {defaultImages.map((img) => (
+            <div
+              key={img.url}
+              className="bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow"
+            >
+              <img
+                src={img.url}
+                alt={img.title}
+                className="w-full h-48 object-cover"
+                loading="lazy"
+              />
+              <div className="p-4">
+                <h3 className="font-medium text-gray-800 dark:text-gray-200">
+                  {img.title}
+                </h3>
+                <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  {img.description}
+                </p>
+                <p className="mt-2 text-xs text-gray-500 dark:text-gray-500">
+                  Categories: {img.categories.join(', ')}
+                </p>
+              </div>
+            </div>
+          ))}
         </div>
       ) : displayedBookmarks.length === 0 ? (
         <div className="text-center py-12">

--- a/src/data/defaultImages.ts
+++ b/src/data/defaultImages.ts
@@ -1,0 +1,46 @@
+export interface DefaultImage {
+  url: string;
+  title: string;
+  description: string;
+  categories: string[];
+}
+
+export const defaultImages: DefaultImage[] = [
+  {
+    url: 'https://i.postimg.cc/CB7x5QxL/cat1.webp',
+    title: 'Cat 1',
+    description: 'A fluffy orange cat with big round eyes sitting upright. Its soft fur and curious expression make it look both regal and cuddly.',
+    categories: ['Realistic'],
+  },
+  {
+    url: 'https://i.postimg.cc/nMVLgp3s/cat2.png',
+    title: 'Cat 2',
+    description: 'A cartoon-style drawing of a cat with an exaggeratedly round head and tiny body. Its simple design gives it a cute, playful look.',
+    categories: ['Cartoon', 'Minimal'],
+  },
+  {
+    url: 'https://i.postimg.cc/ctJ4nBv7/cat3.webp',
+    title: 'Cat 3',
+    description: 'A realistic illustration of a gray tabby cat with striking green eyes. The detailed shading highlights the cat’s fur patterns and alert gaze.',
+    categories: ['Realistic'],
+  },
+  {
+    url: 'https://i.postimg.cc/vDPmdkK0/cat4.png',
+    title: 'Cat 4',
+    description: 'A pixel-art style cat, sitting in a calm pose. The retro aesthetic makes it look like it belongs in a classic video game.',
+    categories: ['Cartoon', 'Minimal'],
+  },
+  {
+    url: 'https://i.postimg.cc/YhhC28KM/cat5.png',
+    title: 'Cat 5',
+    description: 'A minimalistic line-art drawing of a cat. The design is clean, with smooth curves that outline the cat’s head and whiskers in a very simple but expressive way.',
+    categories: ['Minimal'],
+  },
+  {
+    url: 'https://i.postimg.cc/7fdY57w7/cat6.png',
+    title: 'Cat 6',
+    description: 'A stylized cartoon cat with big, shiny eyes and a round face. Its playful and friendly look gives it a very approachable, mascot-like vibe.',
+    categories: ['Cartoon'],
+  },
+];
+


### PR DESCRIPTION
## Summary
- include a set of six sample cat images with descriptions and categories
- render these default images in the gallery when there are no bookmarks

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1dbd7d9dc8323ae0e481acc9dada0