### PR TITLE
fix: remove unused default images import

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -5,7 +5,6 @@ import { addBookmark, loadBookmarks, removeBookmark, removeBookmarks } from '../
 import { formatDate, isValidImageUrl } from '../utils/validation';
 import { searchImages } from '../utils/search';
 import EditBookmarkModal from './EditBookmarkModal';
-import { defaultImages } from '../data/defaultImages';
 
 interface GalleryProps {
   onImageClick: (index: number, items: ImageBookmark[]) => void;


### PR DESCRIPTION
## Summary
- remove unused default images import from Gallery component

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1e02c98788323ab2ecaa318c72659