### PR TITLE
Rename default image titles to Cat 1-6

### DIFF
--- a/src/data/defaultImages.ts
+++ b/src/data/defaultImages.ts
@@ -8,37 +8,37 @@ export interface DefaultImage {
 export const defaultImages: DefaultImage[] = [
   {
     url: 'https://i.postimg.cc/CB7x5QxL/cat1.webp',
-    title: 'Fluffy Orange Cat',
+    title: 'Cat 1',
     description: 'A fluffy orange cat with big round eyes sitting upright. Its soft fur and curious expression make it look both regal and cuddly.',
     categories: ['Realistic'],
   },
   {
     url: 'https://i.postimg.cc/nMVLgp3s/cat2.png',
-    title: 'Round Cartoon Cat',
+    title: 'Cat 2',
     description: 'A cartoon-style drawing of a cat with an exaggeratedly round head and tiny body. Its simple design gives it a cute, playful look.',
     categories: ['Cartoon', 'Minimal'],
   },
   {
     url: 'https://i.postimg.cc/ctJ4nBv7/cat3.webp',
-    title: 'Green-Eyed Tabby',
+    title: 'Cat 3',
     description: 'A realistic illustration of a gray tabby cat with striking green eyes. The detailed shading highlights the cat’s fur patterns and alert gaze.',
     categories: ['Realistic'],
   },
   {
     url: 'https://i.postimg.cc/vDPmdkK0/cat4.png',
-    title: 'Pixel Art Cat',
+    title: 'Cat 4',
     description: 'A pixel-art style cat, sitting in a calm pose. The retro aesthetic makes it look like it belongs in a classic video game.',
     categories: ['Cartoon', 'Minimal'],
   },
   {
     url: 'https://i.postimg.cc/YhhC28KM/cat5.png',
-    title: 'Minimal Line Art Cat',
+    title: 'Cat 5',
     description: 'A minimalistic line-art drawing of a cat. The design is clean, with smooth curves that outline the cat’s head and whiskers in a very simple but expressive way.',
     categories: ['Minimal'],
   },
   {
     url: 'https://i.postimg.cc/7fdY57w7/cat6.png',
-    title: 'Friendly Mascot Cat',
+    title: 'Cat 6',
     description: 'A stylized cartoon cat with big, shiny eyes and a round face. Its playful and friendly look gives it a very approachable, mascot-like vibe.',
     categories: ['Cartoon'],
   },


### PR DESCRIPTION
## Summary
- Simplify the titles for bundled example images to Cat 1 through Cat 6

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1e53cabd483238c5c0693015677c9