### PR TITLE
feat: expand default cat image titles

### DIFF
--- a/src/data/defaultImages.ts
+++ b/src/data/defaultImages.ts
@@ -8,37 +8,43 @@ export interface DefaultImage {
 export const defaultImages: DefaultImage[] = [
   {
     url: 'https://i.postimg.cc/CB7x5QxL/cat1.webp',
-    title: 'Cat 1',
+    title:
+      'A fluffy orange cat with big round eyes sitting upright. Its soft fur and curious expression make it look both regal and cuddly.',
     description: 'A fluffy orange cat with big round eyes sitting upright. Its soft fur and curious expression make it look both regal and cuddly.',
     categories: ['Realistic'],
   },
   {
     url: 'https://i.postimg.cc/nMVLgp3s/cat2.png',
-    title: 'Cat 2',
+    title:
+      'A cartoon-style drawing of a cat with an exaggeratedly round head and tiny body. Its simple design gives it a cute, playful look.',
     description: 'A cartoon-style drawing of a cat with an exaggeratedly round head and tiny body. Its simple design gives it a cute, playful look.',
     categories: ['Cartoon', 'Minimal'],
   },
   {
     url: 'https://i.postimg.cc/ctJ4nBv7/cat3.webp',
-    title: 'Cat 3',
+    title:
+      'A realistic illustration of a gray tabby cat with striking green eyes. The detailed shading highlights the cat’s fur patterns and alert gaze.',
     description: 'A realistic illustration of a gray tabby cat with striking green eyes. The detailed shading highlights the cat’s fur patterns and alert gaze.',
     categories: ['Realistic'],
   },
   {
     url: 'https://i.postimg.cc/vDPmdkK0/cat4.png',
-    title: 'Cat 4',
+    title:
+      'A pixel-art style cat, sitting in a calm pose. The retro aesthetic makes it look like it belongs in a classic video game.',
     description: 'A pixel-art style cat, sitting in a calm pose. The retro aesthetic makes it look like it belongs in a classic video game.',
     categories: ['Cartoon', 'Minimal'],
   },
   {
     url: 'https://i.postimg.cc/YhhC28KM/cat5.png',
-    title: 'Cat 5',
+    title:
+      'A minimalistic line-art drawing of a cat. The design is clean, with smooth curves that outline the cat’s head and whiskers in a very simple but expressive way.',
     description: 'A minimalistic line-art drawing of a cat. The design is clean, with smooth curves that outline the cat’s head and whiskers in a very simple but expressive way.',
     categories: ['Minimal'],
   },
   {
     url: 'https://i.postimg.cc/7fdY57w7/cat6.png',
-    title: 'Cat 6',
+    title:
+      'A stylized cartoon cat with big, shiny eyes and a round face. Its playful and friendly look gives it a very approachable, mascot-like vibe.',
     description: 'A stylized cartoon cat with big, shiny eyes and a round face. Its playful and friendly look gives it a very approachable, mascot-like vibe.',
     categories: ['Cartoon'],
   },


### PR DESCRIPTION
## Summary
- use descriptive phrases as titles for the six default cat images

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c200d82a888323ae92fd573b66edb0