### PR TITLE
Display bookmark categories in Gallery component

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1020,6 +1020,18 @@ export default function Gallery({
                             </button>
                           </div>
                           <p className="text-xs opacity-80">{formatDate(bookmark.createdAt)}</p>
+                          {bookmark.categories && bookmark.categories.length > 0 && (
+                            <div className="mt-2 flex flex-wrap gap-1.5">
+                              {bookmark.categories.map((category) => (
+                                <span
+                                  key={`${bookmark.id}-${category}`}
+                                  className="rounded-full bg-white/20 px-2 py-0.5 text-[11px] text-white"
+                                >
+                                  {category}
+                                </span>
+                              ))}
+                            </div>
+                          )}
                           <div className="flex items-start mt-1">
                             <a
                               href={bookmark.url}


### PR DESCRIPTION
### Motivation
- Add visual display of bookmark categories to gallery items to provide contextual tags and improve discoverability.

### Description
- Conditionally render `bookmark.categories` in `Gallery.tsx` by mapping each category to a styled `<span>` with a unique key `${bookmark.id}-${category}` and compact styling when `bookmark.categories.length > 0`.

### Testing
- Ran type checking and the test suite with `npm run build` and `npm test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d04dd1aee08323afd5e8c3b5468f63)