### PR TITLE
Remove category chips from lightbox overlay

### DIFF
--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -106,8 +106,7 @@ export default function Lightbox({
   };
 
   const title = currentBookmark.title;
-  const categories = currentBookmark.categories ?? [];
-  const hasInfo = Boolean(title) || categories.length > 0;
+  const hasInfo = Boolean(title);
 
   return (
     <div 
@@ -352,18 +351,6 @@ export default function Lightbox({
                 </div>
               )}
 
-              {categories.length > 0 && (
-                <div className="inline-flex flex-wrap justify-center gap-2 max-w-2xl">
-                  {categories.map((category) => (
-                    <span
-                      key={category}
-                      className="px-2.5 py-1 rounded-full bg-white/20 text-sm text-white"
-                    >
-                      {category}
-                    </span>
-                  ))}
-                </div>
-              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
### Motivation
- The lightbox overlay should no longer show category chips; the info panel should only display the title when present, per UI simplification.

### Description
- Removed category chip rendering from `src/components/Lightbox.tsx` and updated the `hasInfo` check to depend only on the presence of `title`, while keeping title display and the copy-title button unchanged.

### Testing
- Ran `npm run build` (which invokes `tsc -b && vite build`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d053347ecc8323807f02312ca2c158)