### PR TITLE
Show sample gallery on home with login modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { buildBookmarksCsv, parseBookmarksCsv } from './utils/csv';
 import { useAuth } from './auth/useAuth';
 import Header from './components/Header';
 import AuthScreen from './components/AuthScreen';
+import SampleGallery from './components/SampleGallery';
 import InputBar from './components/InputBar';
 import Gallery from './components/Gallery';
 import Lightbox from './components/Lightbox';
@@ -45,6 +46,7 @@ export default function App() {
   const [customCategories, setCustomCategories] = useState<string[]>([]);
   const [csvStatus, setCsvStatus] = useState<string | null>(null);
   const [csvError, setCsvError] = useState<string | null>(null);
+  const [showAuthModal, setShowAuthModal] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const hasLoadedBookmarksRef = useRef(false);
 
@@ -435,7 +437,17 @@ export default function App() {
     );
   }
 
-  if (!isConfigured || !user) {
+  if (!user) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
+        <Header onLogIn={() => setShowAuthModal(true)} />
+        <SampleGallery />
+        {showAuthModal && <AuthScreen displayMode="modal" onClose={() => setShowAuthModal(false)} />}
+      </div>
+    );
+  }
+
+  if (!isConfigured) {
     return <AuthScreen />;
   }
 

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -1,7 +1,12 @@
 import { useState } from 'react';
 import { useAuth } from '../auth/useAuth';
 
-export default function AuthScreen() {
+interface AuthScreenProps {
+  displayMode?: 'page' | 'modal';
+  onClose?: () => void;
+}
+
+export default function AuthScreen({ displayMode = 'page', onClose }: AuthScreenProps) {
   const { signIn, signUp, isConfigured } = useAuth();
   const [mode, setMode] = useState<'signin' | 'signup'>('signin');
   const [email, setEmail] = useState('');
@@ -44,94 +49,117 @@ export default function AuthScreen() {
     }
   };
 
-  return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center px-4">
-      <div className="w-full max-w-md rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-6">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Image Bookmarker</h1>
-        <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
-          Sign in to access your bookmarks.
-        </p>
-
-        {!isConfigured && (
-          <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-200">
-            Supabase is not configured. Add `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` to your env file.
-          </div>
-        )}
-
-        <form onSubmit={handleSubmit} className="mt-6 space-y-4">
-          <div>
-            <label htmlFor="auth-email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Email
-            </label>
-            <input
-              id="auth-email"
-              type="email"
-              value={email}
-              onChange={(event) => setEmail(event.target.value)}
-              className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-white"
-              placeholder="you@example.com"
-              autoComplete="email"
-              disabled={loading || !isConfigured}
-              required
-            />
-          </div>
-
-          <div>
-            <label htmlFor="auth-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Password
-            </label>
-            <input
-              id="auth-password"
-              type="password"
-              value={password}
-              onChange={(event) => setPassword(event.target.value)}
-              className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-white"
-              placeholder="••••••••"
-              autoComplete={mode === 'signin' ? 'current-password' : 'new-password'}
-              disabled={loading || !isConfigured}
-              minLength={6}
-              required
-            />
-          </div>
-
-          {error && (
-            <div className="text-sm text-red-600 dark:text-red-300">{error}</div>
-          )}
-          {status && (
-            <div className="text-sm text-emerald-600 dark:text-emerald-300">{status}</div>
-          )}
-
-          <button
-            type="submit"
-            className="w-full rounded-md bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 px-4 py-2 text-white font-medium"
-            disabled={loading || !isConfigured}
-          >
-            {loading
-              ? mode === 'signin'
-                ? 'Signing in...'
-                : 'Creating account...'
-              : mode === 'signin'
-                ? 'Sign in'
-                : 'Create account'}
-          </button>
-        </form>
-
-        <div className="mt-4 text-sm text-gray-600 dark:text-gray-300">
-          {mode === 'signin' ? "Don't have an account?" : 'Already have an account?'}{' '}
+  const authCard = (
+    <div className="w-full max-w-md rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-6">
+      {displayMode === 'modal' && onClose && (
+        <div className="flex justify-end">
           <button
             type="button"
-            onClick={() => {
-              setMode((prev) => (prev === 'signin' ? 'signup' : 'signin'));
-              setError(null);
-              setStatus(null);
-            }}
-            className="text-blue-600 dark:text-blue-300 hover:underline"
-            disabled={loading || !isConfigured}
+            onClick={onClose}
+            className="rounded-md px-2 py-1 text-xs font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white"
           >
-            {mode === 'signin' ? 'Create one' : 'Sign in'}
+            Close
           </button>
         </div>
+      )}
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Image Bookmarker</h1>
+      <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+        Sign in to access your bookmarks.
+      </p>
+
+      {!isConfigured && (
+        <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-200">
+          Supabase is not configured. Add `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` to your env file.
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+        <div>
+          <label htmlFor="auth-email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Email
+          </label>
+          <input
+            id="auth-email"
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-white"
+            placeholder="you@example.com"
+            autoComplete="email"
+            disabled={loading || !isConfigured}
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="auth-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Password
+          </label>
+          <input
+            id="auth-password"
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-white"
+            placeholder="••••••••"
+            autoComplete={mode === 'signin' ? 'current-password' : 'new-password'}
+            disabled={loading || !isConfigured}
+            minLength={6}
+            required
+          />
+        </div>
+
+        {error && (
+          <div className="text-sm text-red-600 dark:text-red-300">{error}</div>
+        )}
+        {status && (
+          <div className="text-sm text-emerald-600 dark:text-emerald-300">{status}</div>
+        )}
+
+        <button
+          type="submit"
+          className="w-full rounded-md bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 px-4 py-2 text-white font-medium"
+          disabled={loading || !isConfigured}
+        >
+          {loading
+            ? mode === 'signin'
+              ? 'Signing in...'
+              : 'Creating account...'
+            : mode === 'signin'
+              ? 'Sign in'
+              : 'Create account'}
+        </button>
+      </form>
+
+      <div className="mt-4 text-sm text-gray-600 dark:text-gray-300">
+        {mode === 'signin' ? "Don't have an account?" : 'Already have an account?'}{' '}
+        <button
+          type="button"
+          onClick={() => {
+            setMode((prev) => (prev === 'signin' ? 'signup' : 'signin'));
+            setError(null);
+            setStatus(null);
+          }}
+          className="text-blue-600 dark:text-blue-300 hover:underline"
+          disabled={loading || !isConfigured}
+        >
+          {mode === 'signin' ? 'Create one' : 'Sign in'}
+        </button>
       </div>
+    </div>
+  );
+
+  if (displayMode === 'modal') {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+        {authCard}
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center px-4">
+      {authCard}
     </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,9 +4,10 @@ import ThemeToggle from './ThemeToggle';
 interface HeaderProps {
   userEmail?: string;
   onSignOut?: () => Promise<void>;
+  onLogIn?: () => void;
 }
 
-export default function Header({ userEmail, onSignOut }: HeaderProps) {
+export default function Header({ userEmail, onSignOut, onLogIn }: HeaderProps) {
   const [isSigningOut, setIsSigningOut] = useState(false);
 
   const handleSignOut = async () => {
@@ -41,6 +42,15 @@ export default function Header({ userEmail, onSignOut }: HeaderProps) {
               disabled={isSigningOut}
             >
               {isSigningOut ? 'Signing out...' : 'Sign out'}
+            </button>
+          )}
+          {!onSignOut && onLogIn && (
+            <button
+              type="button"
+              onClick={onLogIn}
+              className="rounded-md bg-blue-600 hover:bg-blue-700 px-3 py-1 text-xs font-medium text-white"
+            >
+              Log in
             </button>
           )}
           <ThemeToggle />

--- a/src/components/SampleGallery.tsx
+++ b/src/components/SampleGallery.tsx
@@ -1,0 +1,36 @@
+import { defaultImages } from '../data/defaultImages';
+
+export default function SampleGallery() {
+  return (
+    <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <section className="mb-6 rounded-xl border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-100">
+        Explore a sample gallery before signing in. Log in to add, edit, and organize your own image bookmarks.
+      </section>
+
+      <section className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {defaultImages.map((image) => (
+          <article
+            key={image.url}
+            className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800"
+          >
+            <img src={image.url} alt={image.title} className="h-56 w-full object-cover" loading="lazy" />
+            <div className="space-y-3 p-4">
+              <h2 className="line-clamp-2 text-sm font-semibold text-gray-900 dark:text-white">{image.title}</h2>
+              <p className="line-clamp-3 text-sm text-gray-600 dark:text-gray-300">{image.description}</p>
+              <div className="flex flex-wrap gap-2">
+                {image.categories.map((category) => (
+                  <span
+                    key={`${image.url}-${category}`}
+                    className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+                  >
+                    {category}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- Improve the unauthenticated landing experience by showing a read-only sample images interface instead of only an auth box.
- Provide a clear `Log in` affordance that opens an authentication modal so users can preview the app before signing in.

### Description
- Render a new `SampleGallery` component on the home screen for signed-out users and add `showAuthModal` state in `App.tsx` to control the modal login flow (`src/App.tsx`).
- Add an optional `onLogIn` prop to `Header` and render a top-right `Log in` button for signed-out users to open the modal (`src/components/Header.tsx`).
- Refactor `AuthScreen` to accept `displayMode: 'page' | 'modal'` and an optional `onClose` callback, and render as an overlay modal when requested (`src/components/AuthScreen.tsx`).
- Add `SampleGallery` component that displays cards from `defaultImages` as a read-only preview (`src/components/SampleGallery.tsx`).

### Testing
- Ran the production build with `npm run build` and the build completed successfully after fixes to the auth component types and modal rendering.
- No automated unit tests are present; the build is the primary automated validation performed and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbcfd7a0883239fc08de514d07588)