### PR TITLE
Remove unused SampleGallery import to fix TS6133 build error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,6 @@ import { defaultImages } from './data/defaultImages';
 import { useAuth } from './auth/useAuth';
 import Header from './components/Header';
 import AuthScreen from './components/AuthScreen';
-import SampleGallery from './components/SampleGallery';
 import InputBar from './components/InputBar';
 import Gallery from './components/Gallery';
 import Lightbox from './components/Lightbox';


### PR DESCRIPTION
### Motivation
- Fix the TypeScript `TS6133` build error on Vercel caused by an unused `SampleGallery` import in `src/App.tsx`.

### Description
- Removed the unused `SampleGallery` import from `src/App.tsx`.

### Testing
- Ran `npm run build` which completed successfully after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc40935648323ad715328d6031e99)