### PR TITLE
Add category exclusion filters to gallery browsing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ export default function App() {
   const [lightboxBookmarks, setLightboxBookmarks] = useState<ImageBookmark[]>([]);
   const [lightboxOverlayOpacity, setLightboxOverlayOpacity] = useState(0.9);
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const [excludedCategories, setExcludedCategories] = useState<string[]>([]);
   const [showInputBar, setShowInputBar] = useState(false);
   const [showSearch, setShowSearch] = useState(false);
   const [selectMode, setSelectMode] = useState(false);
@@ -269,6 +270,10 @@ export default function App() {
       const next = prev.filter((category) => categories.includes(category));
       return next.length === prev.length ? prev : next;
     });
+    setExcludedCategories((prev) => {
+      const next = prev.filter((category) => categories.includes(category));
+      return next.length === prev.length ? prev : next;
+    });
   }, [categories]);
 
   const handleAddCategory = async () => {
@@ -312,6 +317,7 @@ export default function App() {
       const updatedBookmarks = await removeCategoryFromBookmarks(category);
       setBookmarks(updatedBookmarks);
       setSelectedCategories((prev) => prev.filter((item) => item !== category));
+      setExcludedCategories((prev) => prev.filter((item) => item !== category));
       setRefreshTrigger((prev) => prev + 1);
     } catch (error) {
       console.error('Failed to delete category from bookmarks:', error);
@@ -488,6 +494,7 @@ export default function App() {
           <CategorySelector
             categories={Array.from(new Set(previewBookmarks.flatMap((bookmark) => bookmark.categories ?? [])))}
             selected={selectedCategories}
+            excluded={excludedCategories}
             onToggle={(category) => {
               setSelectedCategories((prev) =>
                 prev.includes(category)
@@ -495,7 +502,15 @@ export default function App() {
                   : [...prev, category]
               );
             }}
+            onToggleExcluded={(category) => {
+              setExcludedCategories((prev) =>
+                prev.includes(category)
+                  ? prev.filter((item) => item !== category)
+                  : [...prev, category]
+              );
+            }}
             onClear={() => setSelectedCategories([])}
+            onClearExcluded={() => setExcludedCategories([])}
             onAddCategory={() => setShowAuthModal(true)}
             onDeleteCategory={() => setShowAuthModal(true)}
             readOnly
@@ -557,6 +572,7 @@ export default function App() {
             onImageClick={handleImageClick}
             onAddBookmark={() => {}}
             selectedCategories={selectedCategories}
+            excludedCategories={excludedCategories}
             selectMode={false}
             setSelectMode={() => {}}
             showSearch={showSearch}
@@ -657,6 +673,7 @@ export default function App() {
             <CategorySelector
               categories={categories}
               selected={selectedCategories}
+              excluded={excludedCategories}
               onToggle={(category) => {
                 setSelectedCategories((prev) =>
                   prev.includes(category)
@@ -664,7 +681,15 @@ export default function App() {
                     : [...prev, category]
                 );
               }}
+              onToggleExcluded={(category) => {
+                setExcludedCategories((prev) =>
+                  prev.includes(category)
+                    ? prev.filter((item) => item !== category)
+                    : [...prev, category]
+                );
+              }}
               onClear={() => setSelectedCategories([])}
+              onClearExcluded={() => setExcludedCategories([])}
               onAddCategory={() => void handleAddCategory()}
               onDeleteCategory={(category) => {
                 void handleDeleteCategory(category);
@@ -731,6 +756,7 @@ export default function App() {
           onImageClick={handleImageClick}
           onAddBookmark={handleAddBookmark}
           selectedCategories={selectedCategories}
+          excludedCategories={excludedCategories}
           selectMode={selectMode}
           setSelectMode={setSelectMode}
           showSearch={showSearch}

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -3,8 +3,11 @@ import { useState } from 'react';
 interface CategorySelectorProps {
   categories: string[];
   selected: string[];
+  excluded: string[];
   onToggle: (category: string) => void;
+  onToggleExcluded: (category: string) => void;
   onClear: () => void;
+  onClearExcluded: () => void;
   onAddCategory: () => void;
   onDeleteCategory: (category: string) => void;
   readOnly?: boolean;
@@ -13,8 +16,11 @@ interface CategorySelectorProps {
 export default function CategorySelector({
   categories,
   selected,
+  excluded,
   onToggle,
+  onToggleExcluded,
   onClear,
+  onClearExcluded,
   onAddCategory,
   onDeleteCategory,
   readOnly = false,
@@ -99,6 +105,39 @@ export default function CategorySelector({
             </div>
           );
         })}
+      </div>
+      <div className="mt-3">
+        <p className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          Exclude categories
+        </p>
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          <button
+            type="button"
+            onClick={onClearExcluded}
+            className={`inline-flex flex-shrink-0 items-center whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium shadow-sm transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1 ${excluded.length === 0
+              ? 'bg-red-600 text-white hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600'
+              : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
+              }`}
+          >
+            Hide none
+          </button>
+          {categories.map((cat) => {
+            const isExcluded = excluded.includes(cat);
+            return (
+              <button
+                key={`excluded-${cat}`}
+                type="button"
+                onClick={() => onToggleExcluded(cat)}
+                className={`inline-flex flex-shrink-0 items-center whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium shadow-sm transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1 ${isExcluded
+                  ? 'bg-red-600 text-white hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
+                  }`}
+              >
+                {cat}
+              </button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -75,6 +75,7 @@ interface GalleryProps {
   onImageClick: (index: number, items: ImageBookmark[]) => void;
   onAddBookmark: () => void;
   selectedCategories: string[];
+  excludedCategories: string[];
   selectMode: boolean;
   setSelectMode: Dispatch<SetStateAction<boolean>>;
   showSearch: boolean;
@@ -91,6 +92,7 @@ export default function Gallery({
   onImageClick,
   onAddBookmark,
   selectedCategories,
+  excludedCategories,
   selectMode,
   setSelectMode,
   showSearch,
@@ -125,8 +127,8 @@ export default function Gallery({
 
   const paginationKey = useMemo(() => {
     const normalizedSearch = debouncedSearch.trim().toLowerCase();
-    return `${selectedCategories.join(',')}::${normalizedSearch}::${searchFrom}::${searchTo}::${showDuplicatesOnly ? 'dupes' : 'all'}::${showUntitledOnly ? 'only-untitled' : 'all-titles'}`;
-  }, [selectedCategories, debouncedSearch, searchFrom, searchTo, showDuplicatesOnly, showUntitledOnly]);
+    return `${selectedCategories.join(',')}::${excludedCategories.join(',')}::${normalizedSearch}::${searchFrom}::${searchTo}::${showDuplicatesOnly ? 'dupes' : 'all'}::${showUntitledOnly ? 'only-untitled' : 'all-titles'}`;
+  }, [selectedCategories, excludedCategories, debouncedSearch, searchFrom, searchTo, showDuplicatesOnly, showUntitledOnly]);
 
   useEffect(() => {
     try {
@@ -500,12 +502,20 @@ export default function Gallery({
   }, [bookmarks]);
 
   const filteredByCategory = useMemo(() => (
-    selectedCategories.length === 0
-      ? bookmarks
-      : bookmarks.filter((bookmark) =>
-        selectedCategories.every((category) => bookmark.categories?.includes(category))
-      )
-  ), [bookmarks, selectedCategories]);
+    bookmarks.filter((bookmark) => {
+      const matchesIncluded = selectedCategories.length === 0
+        || selectedCategories.every((category) => bookmark.categories?.includes(category));
+      if (!matchesIncluded) {
+        return false;
+      }
+
+      if (excludedCategories.length === 0) {
+        return true;
+      }
+
+      return !excludedCategories.some((category) => bookmark.categories?.includes(category));
+    })
+  ), [bookmarks, selectedCategories, excludedCategories]);
 
   const filteredBookmarks = useMemo(() => (
     showDuplicatesOnly


### PR DESCRIPTION
### Motivation
- Provide users a way to explicitly exclude categories from their browsing results in addition to the existing include filters.
- Keep pagination and view persistence consistent when the filter state changes by including exclusion state in the pagination key.
- Surface exclusion controls in the UI so users can toggle and clear excluded categories quickly.

### Description
- Add `excludedCategories` state in `App` and wire it into both the preview and authenticated flows so exclusion is preserved and cleaned up when categories are deleted. (`src/App.tsx`).
- Extend `CategorySelector` props and UI with an "Exclude categories" row and a clear action labeled `Hide none`, and add handlers `onToggleExcluded` and `onClearExcluded`. (`src/components/CategorySelector.tsx`).
- Update `Gallery` to accept `excludedCategories`, include it in the `paginationKey`, and change filtering so bookmarks must match included categories and are omitted if they contain any excluded category. (`src/components/Gallery.tsx`).

### Testing
- Ran a full production build with `npm run build`, which completed successfully (TypeScript compile + `vite build`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3fad730a88323af50dc8268380c80)