### PR TITLE
Add Google search button beside displayed image titles

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1019,6 +1019,31 @@ export default function Gallery({
                             <button
                               onClick={(e) => {
                                 e.stopPropagation();
+                                const titleQuery = bookmark.title || 'Untitled';
+                                window.open(
+                                  `https://www.google.com/search?q=${encodeURIComponent(titleQuery)}`,
+                                  '_blank',
+                                  'noopener,noreferrer'
+                                );
+                              }}
+                              className="ml-2 p-1 hover:text-blue-300"
+                              aria-label="Search title on Google"
+                              title="Search title on Google"
+                            >
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                className="h-4 w-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                              >
+                                <circle cx="11" cy="11" r="8" strokeWidth={2} />
+                                <path strokeWidth={2} strokeLinecap="round" d="M21 21l-4.35-4.35" />
+                              </svg>
+                            </button>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
                                 void navigator.clipboard.writeText(
                                   bookmark.title || 'Untitled'
                                 );

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -336,6 +336,26 @@ export default function Lightbox({
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
+                      if (title) {
+                        window.open(
+                          `https://www.google.com/search?q=${encodeURIComponent(title)}`,
+                          '_blank',
+                          'noopener,noreferrer'
+                        );
+                      }
+                    }}
+                    className="p-1.5 bg-black/50 text-white hover:bg-black/70 rounded-full"
+                    aria-label="Search title on Google"
+                    title="Search title on Google"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <circle cx="11" cy="11" r="8" strokeWidth={2} />
+                      <path strokeLinecap="round" strokeWidth={2} d="M21 21l-4.35-4.35" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
                       if (title && navigator?.clipboard?.writeText) {
                         navigator.clipboard.writeText(title);
                       }


### PR DESCRIPTION
### Motivation
- Provide a quick way to search an image's title text in Google by adding a search icon next to the copy button when the title is visible.
- Improve discoverability and make it easier for users to look up image descriptions without manual copying and pasting.

### Description
- Added a search icon button in the gallery card title overlay in `src/components/Gallery.tsx` that opens a new tab to Google with the title prefilled (falls back to `"Untitled"`).
- Added the same search icon button to the lightbox title row in `src/components/Lightbox.tsx` that opens Google with the displayed title as the query.
- Buttons use `window.open` with `encodeURIComponent` for the query, call `e.stopPropagation()` to avoid triggering parent click handlers, and include `aria-label` and `title` attributes for accessibility.

### Testing
- Built the project with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee602cc96c83238544521a1e835f79)