### PR TITLE
Add bulk category injection (add or replace mode)

### DIFF
--- a/src/components/BulkEditModal.tsx
+++ b/src/components/BulkEditModal.tsx
@@ -5,7 +5,10 @@ interface BulkEditModalProps {
   selectedCount: number;
   allCategories: string[];
   onClose: () => void;
-  onSave: (updates: Partial<Omit<ImageBookmark, 'id' | 'createdAt' | 'searchTokens'>>) => void;
+  onSave: (
+    updates: Partial<Omit<ImageBookmark, 'id' | 'createdAt' | 'searchTokens'>>,
+    options?: { categoryMode?: 'replace' | 'add' }
+  ) => void;
 }
 
 export default function BulkEditModal({
@@ -19,6 +22,7 @@ export default function BulkEditModal({
   const [newCategory, setNewCategory] = useState('');
   const [applyTitle, setApplyTitle] = useState(false);
   const [applyCategories, setApplyCategories] = useState(false);
+  const [categoryMode, setCategoryMode] = useState<'add' | 'replace'>('add');
 
   const toggleCategory = (cat: string) => {
     setCategories((prev) => (prev.includes(cat) ? prev.filter((c) => c !== cat) : [...prev, cat]));
@@ -43,10 +47,11 @@ export default function BulkEditModal({
       updates.categories = categories.length > 0 ? categories : undefined;
     }
 
-    onSave(updates);
+    onSave(updates, { categoryMode });
   };
 
-  const isSaveDisabled = !applyTitle && !applyCategories;
+  const isSaveDisabled =
+    !applyTitle && (!applyCategories || (categoryMode === 'add' && categories.length === 0));
 
   return (
     <div
@@ -62,7 +67,7 @@ export default function BulkEditModal({
       >
         <h2 className="text-lg font-medium mb-2">Edit {selectedCount} selected</h2>
         <p className="text-sm text-gray-300 mb-4">
-          Apply the same title or categories to all selected bookmarks.
+          Apply the same title, replace categories, or add categories to all selected bookmarks.
         </p>
         <div className="mb-4">
           <label className="flex items-center gap-2 mb-1 text-sm">
@@ -91,6 +96,33 @@ export default function BulkEditModal({
             />
             Apply categories
           </label>
+          <fieldset className={`mb-3 ${applyCategories ? '' : 'opacity-50'}`}>
+            <legend className="sr-only">Category update mode</legend>
+            <div className="flex flex-col gap-2 text-sm sm:flex-row sm:gap-4">
+              <label className="inline-flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="bulk-category-mode"
+                  value="add"
+                  checked={categoryMode === 'add'}
+                  onChange={() => setCategoryMode('add')}
+                  disabled={!applyCategories}
+                />
+                Add to existing categories
+              </label>
+              <label className="inline-flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="bulk-category-mode"
+                  value="replace"
+                  checked={categoryMode === 'replace'}
+                  onChange={() => setCategoryMode('replace')}
+                  disabled={!applyCategories}
+                />
+                Replace categories
+              </label>
+            </div>
+          </fieldset>
           <div className={`flex flex-wrap gap-2 mb-2 ${applyCategories ? '' : 'opacity-50'}`}>
             {[...new Set([...allCategories, ...categories])].map((cat) => (
               <label key={cat} className="inline-flex items-center">

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -342,7 +342,8 @@ export default function Gallery({
   };
 
   const handleBulkEditSave = async (
-    updates: Partial<Omit<ImageBookmark, 'id' | 'createdAt' | 'searchTokens'>>
+    updates: Partial<Omit<ImageBookmark, 'id' | 'createdAt' | 'searchTokens'>>,
+    options?: { categoryMode?: 'replace' | 'add' }
   ) => {
     if (readOnly) {
       return;
@@ -358,9 +359,23 @@ export default function Gallery({
         return bookmark;
       }
 
-      const nextCategories = 'categories' in updates
-        ? updates.categories?.map((category) => category.trim()).filter(Boolean)
-        : bookmark.categories;
+      const nextCategories = (() => {
+        if (!('categories' in updates)) {
+          return bookmark.categories;
+        }
+
+        const normalizedUpdateCategories = updates.categories
+          ?.map((category) => category.trim())
+          .filter(Boolean);
+
+        if (options?.categoryMode === 'add') {
+          return Array.from(
+            new Set([...(bookmark.categories ?? []), ...(normalizedUpdateCategories ?? [])])
+          );
+        }
+
+        return normalizedUpdateCategories;
+      })();
       const nextTitle = 'title' in updates
         ? (updates.title?.trim() || undefined)
         : bookmark.title;
@@ -382,7 +397,7 @@ export default function Gallery({
     setBulkEditing(false);
 
     try {
-      const updatedBookmarks = await updateBookmarksBulk(selectedIds, updates);
+      const updatedBookmarks = await updateBookmarksBulk(selectedIds, updates, options);
       setBookmarks(updatedBookmarks);
       onAddBookmark();
     } catch (error) {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -42,6 +42,9 @@ type CustomCategoryRow = {
 
 type BookmarkCreateInput = Omit<ImageBookmark, 'id' | 'createdAt' | 'searchTokens'>;
 type BookmarkUpdateInput = Partial<Omit<ImageBookmark, 'id' | 'createdAt' | 'searchTokens'>>;
+type BulkBookmarkUpdateOptions = {
+  categoryMode?: 'replace' | 'add';
+};
 
 function assertSupabaseConfigured(): void {
   if (!isSupabaseConfigured) {
@@ -629,7 +632,8 @@ export async function updateBookmark(
 
 export async function updateBookmarksBulk(
   ids: string[],
-  updates: BookmarkUpdateInput
+  updates: BookmarkUpdateInput,
+  options: BulkBookmarkUpdateOptions = {}
 ): Promise<ImageBookmark[]> {
   const userId = await requireAuthenticatedUserId();
   if (ids.length === 0) {
@@ -654,6 +658,7 @@ export async function updateBookmarksBulk(
   const normalizedTitle = 'title' in updates ? normalizeOptionalText(updates.title) : undefined;
   const normalizedCategories =
     'categories' in updates ? normalizeCategoryList(updates.categories) : undefined;
+  const categoryMode = options.categoryMode ?? 'replace';
 
   const rowsToUpsert: BookmarkRow[] = rows.map((row) => {
     const current = rowToBookmark(row);
@@ -664,9 +669,16 @@ export async function updateBookmarksBulk(
       title: 'title' in updates ? normalizedTitle : current.title,
       categories:
         'categories' in updates
-          ? normalizedCategories && normalizedCategories.length > 0
-            ? normalizedCategories
-            : undefined
+          ? categoryMode === 'add'
+            ? (() => {
+                const merged = Array.from(
+                  new Set([...(current.categories ?? []), ...(normalizedCategories ?? [])])
+                );
+                return merged.length > 0 ? merged : undefined;
+              })()
+            : normalizedCategories && normalizedCategories.length > 0
+              ? normalizedCategories
+              : undefined
           : current.categories,
     };
 


### PR DESCRIPTION
### Motivation

- Allow injecting one or more categories into all selected images either by adding to each image's existing categories or by replacing them, so multi-select edits can augment category lists without overwriting them unintentionally.
- Preserve optimistic UI behavior while providing a clear UI choice for add vs replace semantics when bulk-editing categories.

### Description

- Add a category update mode UI to the bulk edit modal (`src/components/BulkEditModal.tsx`) with radio controls for `Add to existing categories` (default) and `Replace categories`, and pass the chosen mode to the save handler. 
- Update the gallery bulk-save flow (`src/components/Gallery.tsx`) to accept an `options` argument and perform optimistic merging of categories per bookmark when `add` mode is selected while keeping replace behavior for `replace` mode. 
- Extend the storage layer (`src/lib/storage.ts`) with a `BulkBookmarkUpdateOptions` type and accept the `categoryMode` option in `updateBookmarksBulk`, merging categories server-side when `add` is requested and preserving replace semantics otherwise.

### Testing

- Built the production bundles with `npm run build`, which succeeded.
- Ran the linter with `npm run lint`, which completed without blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a037c5fe8808323b8faa2540c0871ee)